### PR TITLE
Weighted class selection

### DIFF
--- a/Config/XComLadderOptions.ini
+++ b/Config/XComLadderOptions.ini
@@ -26,14 +26,16 @@ DefaultAlertLevelEnd=5
 ; These classes are taken out of the random class options, and cannot be selected
 +ClassesToHide="PsiOperative"
 
+[ResistanceOperationOverhaul.ResistanceOverhaulHelpers]
+
 ; Should the random class selection use weighted randomness
-UseWeightedClassSelection=true
+bUseWeightedClassSelection=false
 
 ; Default weight of a class if not manually specified
 DEFAULT_CLASS_WEIGHT=20
 
-; Manually set class weight
-+ClassWeights=(ClassName="Skirmisher", Weight=50)
+; Manually set the weight of a specific class
+;+ClassWeights=(ClassName="Skirmisher", Weight=50)
 
 [ResistanceOperationOverhaul.XComGameState_LadderProgress_Override]
 

--- a/Config/XComLadderOptions.ini
+++ b/Config/XComLadderOptions.ini
@@ -26,6 +26,15 @@ DefaultAlertLevelEnd=5
 ; These classes are taken out of the random class options, and cannot be selected
 +ClassesToHide="PsiOperative"
 
+; Should the random class selection use weighted randomness
+UseWeightedClassSelection=true
+
+; Default weight of a class if not manually specified
+DEFAULT_CLASS_WEIGHT=20
+
+; Manually set class weight
++ClassWeights=(ClassName="Skirmisher", Weight=50)
+
 [ResistanceOperationOverhaul.XComGameState_LadderProgress_Override]
 
 ; Base amount of credits earned after each mission

--- a/Src/ResistanceOperationOverhaul/Classes/AStructs.uc
+++ b/Src/ResistanceOperationOverhaul/Classes/AStructs.uc
@@ -85,3 +85,9 @@ struct TechUpgrade
 	var array<name> RequiredMods;         // This is an OR. At least one mod in the list must be enabled for this upgrade to exist
 	var array<name> IgnoreIfModsEnabled;  // This is an OR. If any mod in this list is enabled, then this upgrade will not exist
 };
+
+struct ClassWeight
+{
+	var name ClassName;
+	var int Weight;
+};

--- a/Src/ResistanceOperationOverhaul/Classes/UITLE_LadderModeMenu_Override.uc
+++ b/Src/ResistanceOperationOverhaul/Classes/UITLE_LadderModeMenu_Override.uc
@@ -39,10 +39,6 @@ var config int DefaultForceLevelEnd;
 var config int DefaultAlertLevelStart;
 var config int DefaultAlertLevelEnd;
 
-var config bool UseWeightedClassSelection;
-var config int DEFAULT_CLASS_WEIGHT;
-var config array<ClassWeight> ClassWeights;
-
 var localized string m_EnableModText;
 var localized string m_SquadText;
 var localized string m_LadderLengthText;

--- a/Src/ResistanceOperationOverhaul/Classes/UITLE_LadderModeMenu_Override.uc
+++ b/Src/ResistanceOperationOverhaul/Classes/UITLE_LadderModeMenu_Override.uc
@@ -39,6 +39,10 @@ var config int DefaultForceLevelEnd;
 var config int DefaultAlertLevelStart;
 var config int DefaultAlertLevelEnd;
 
+var config bool UseWeightedClassSelection;
+var config int DEFAULT_CLASS_WEIGHT;
+var config array<ClassWeight> ClassWeights;
+
 var localized string m_EnableModText;
 var localized string m_SquadText;
 var localized string m_LadderLengthText;


### PR DESCRIPTION
Appeared to work after initial testing, will update later to fully remove the debug logs.
Unfortunately this approach doesn't work unless the `Use custom settings` checkbox is ticked.
https://github.com/Favid/ResistanceOperationOverhaul/blob/6542ed6cb893823791c6dd4f5b728bcbb30f392c/Src/ResistanceOperationOverhaul/Classes/UITLE_LadderModeMenu_Override.uc#L1273-L1278
Is there some specific reason why `InitSquad()` is only called with custom settings enabled? Moved the call locally outside the `if()` and everything still seemed  to work, though did not test further than starting the first mission.